### PR TITLE
feat(m5stack): add optional M5Stack ILI9341 support

### DIFF
--- a/driver/esp32/modILI9341.c
+++ b/driver/esp32/modILI9341.c
@@ -98,7 +98,7 @@ STATIC mp_obj_t ILI9341_make_new(const mp_obj_type_t *type,
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_mhz,MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int=40}},
         { MP_QSTR_spihost,MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int=HSPI_HOST}},
-        { MP_QSTR_miso,MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int=-1}},             
+        { MP_QSTR_miso,MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int=-1}},
         { MP_QSTR_mosi,MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int=-1}},
         { MP_QSTR_clk,MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int=-1}},
         { MP_QSTR_cs,MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int=-1}},
@@ -130,7 +130,7 @@ STATIC const mp_rom_map_elem_t ILI9341_globals_table[] = {
         { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ILI9341) },
         { MP_ROM_QSTR(MP_QSTR_display), (mp_obj_t)&ILI9341_type},
 };
-         
+
 
 STATIC MP_DEFINE_CONST_DICT (
     mp_module_ILI9341_globals,
@@ -294,7 +294,18 @@ STATIC mp_obj_t mp_init_ILI9341(mp_obj_t self_in)
 
 	///Enable backlight
 	//printf("Enable backlight.\n");
-	if (self->backlight != -1) gpio_set_level(self->backlight, 1);       
+	if (self->backlight != -1) gpio_set_level(self->backlight, 1);
+
+#ifdef M5STACK_ILI9341
+	// this same command also sets rotation (portrait/landscape) and inverts colors.
+	// https://gist.github.com/motters/38a26a66020f674b6389063932048e4c#file-ili9844_defines-h-L24
+	ili9441_send_cmd(self, 0x36);
+#define MADCTL_ML      0x10
+#define TFT_RGB_BGR    0x08
+	uint8_t data[] = {(MADCTL_ML | TFT_RGB_BGR)};
+	ili9341_send_data(self, &data, 1);
+#endif
+
     return mp_const_none;
 }
 

--- a/driver/esp32/modILI9341.c
+++ b/driver/esp32/modILI9341.c
@@ -299,11 +299,16 @@ STATIC mp_obj_t mp_init_ILI9341(mp_obj_t self_in)
 #ifdef M5STACK_ILI9341
 	// this same command also sets rotation (portrait/landscape) and inverts colors.
 	// https://gist.github.com/motters/38a26a66020f674b6389063932048e4c#file-ili9844_defines-h-L24
+	//
+	// See also: http://www.newhavendisplay.com/app_notes/ILI9341.pdf
 	ili9441_send_cmd(self, 0x36);
 #define MADCTL_ML      0x10
 #define TFT_RGB_BGR    0x08
 	uint8_t data[] = {(MADCTL_ML | TFT_RGB_BGR)};
 	ili9341_send_data(self, &data, 1);
+#define DINVON         0x21
+	// Turn on display inversion.
+	ili9441_send_cmd(self, DINVON);
 #endif
 
     return mp_const_none;

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -302,7 +302,11 @@ typedef void * lv_indev_drv_user_data_t;            /*Type of user data in the i
 
 /* Robot fonts with bpp = 4
  * https://fonts.google.com/specimen/Roboto  */
+#ifdef M5STACK_ILI9341
+#define LV_FONT_ROBOTO_12    1
+#else
 #define LV_FONT_ROBOTO_12    0
+#endif  // M5STACK_ILI9341
 #define LV_FONT_ROBOTO_16    1
 #define LV_FONT_ROBOTO_22    0
 #define LV_FONT_ROBOTO_28    1
@@ -324,7 +328,11 @@ typedef void * lv_indev_drv_user_data_t;            /*Type of user data in the i
 #define LV_FONT_CUSTOM_DECLARE // LV_FONT_DECLARE(lv_font_heb_16)
 
 /*Always set a default font from the built-in fonts*/
+#ifdef M5STACK_ILI9341
+#define LV_FONT_DEFAULT        &lv_font_roboto_12
+#else
 #define LV_FONT_DEFAULT        &lv_font_roboto_16
+#endif  // M5STACK_ILI9341
 
 /* Enable it if you have fonts with a lot of characters.
  * The limit depends on the font size, font face and bpp


### PR DESCRIPTION
This pull request adds support for [M5Stack cores][m5cores] using the ILI9341 LCD display (e.g., [this one][m5]). Without the changes in this pull request, the display is not properly configured resulting in at least the following issues:

 - horizontally mirrored image
 - inverted color

Also, as part of this pull request, Roboto 12pt is included and selected as the default font to accommodate the small ILI9341 320x240 LCD resolution.

See [sci-bots/m5-lvgl][m5-lvgl] for a MicroPython driver for the M5Stack; including an input driver using the M5Stack A, B, C buttons to emulate an encoder input device. Here is a video demonstrating the functionality:

 [![][demo-thumbnail]][demo-video]

[demo-video]: https://www.youtube.com/watch?v=lpJi6oqPu_4&feature=youtu.be
[demo-thumbnail]: https://trello-attachments.s3.amazonaws.com/5a4e5802bd8b7c317195569d/5dd6d56a74cecc832ce7b61f/5798274fae2f7e186dc2761263dbcd7f/image.png
[m5cores]: https://m5stack.com/collections/m5-core
[m5]: https://m5stack.com/collections/m5-core/products/basic-core-iot-development-kit
[m5-lvgl]: https://github.com/sci-bots/m5-lvgl