### PR TITLE
ili9341: add rotation, backlight high/low set, color mode, and invert

### DIFF
--- a/driver/esp32/ili9341.py
+++ b/driver/esp32/ili9341.py
@@ -41,7 +41,7 @@ class ili9341:
     # "power" and "backlight" are reversed logic! 0 means ON.
 
     def __init__(self,
-        miso=5, mosi=18, clk=19, cs=13, dc=12, rst=4, power=14, backlight=15, backlight_on=1,
+        miso=5, mosi=18, clk=19, cs=13, dc=12, rst=4, power=14, backlight=15, backlight_on=0,
         spihost=esp.HSPI_HOST, mhz=40, factor=4, hybrid=True, width=240, height=320,
         colormode=COLOR_MODE_BGR, rot=MADCTL_MX, invert=False
     ):


### PR DESCRIPTION
I’m working with the [M5Stack](https://m5stack.com) ESP32 device and the ili9341 configuration is a bit different than what was hardcoded into the `ili9341.py` module.

This PR adds a number of options to the initialization of this class that allows configuration of the screen size, rotation mode, backlight (M5Stack requires backlight pin to be pulled high), color mode (RGB vs BGR), and invert mode.

Most of the additions were made based on modifications for the M5Stack in this library: https://github.com/m5stack/M5Stack_TFT_ILI9341/blob/m5stack-default/components/tft/

This code isn’t specific to M5Stack and retains the current default values.

_edit: it looks like PR https://github.com/littlevgl/lv_binding_micropython/pull/54 does something similar, though I tried to implement it in a way that doesn’t specifically pertain to the M5Stack config_