### PR TITLE
fix(ili9341): fix invert kwarg

### DIFF
--- a/driver/esp32/ili9341.py
+++ b/driver/esp32/ili9341.py
@@ -102,7 +102,7 @@ class ili9341:
         ]
 
         if invert:
-            self.init_cmds.append({'cmd': 0x21})
+            self.init_cmds.append({'cmd': 0x21, 'data': bytes([])})
 
         self.init()
 

--- a/driver/esp32/ili9341.py
+++ b/driver/esp32/ili9341.py
@@ -102,7 +102,7 @@ class ili9341:
         ]
 
         if invert:
-            self.init_cmds.append({'cmd': 0x21, 'data': bytes([])})
+            self.init_cmds.append({'cmd': 0x21})
 
         self.init()
 
@@ -291,7 +291,8 @@ class ili9341:
 
         for cmd in self.init_cmds:
             self.send_cmd(cmd['cmd'])
-            self.send_data(cmd['data'])
+            if 'data' in cmd:
+                self.send_data(cmd['data'])
             if 'delay' in cmd:
                 esp.task_delay_ms(cmd['delay'])
 


### PR DESCRIPTION
Prior to this commit, the `ili9341` class `__init__` method would raise
a `KeyError` exception if `invert==True`. The issue was that the
following conditional did not add the required `"data"` key/value pair
to the `init_cmds` list item:

    if invert:
        self.init_cmds.append({'cmd': 0x21})

In this commit, add the required `"data"` key/value pair to the
`init_cmds` list item when `invert==True`.