### PR TITLE
feat(font): optionally override font settings

### DIFF
--- a/lv_conf.h
+++ b/lv_conf.h
@@ -328,7 +328,9 @@ typedef void * lv_indev_drv_user_data_t;            /*Type of user data in the i
 #define LV_FONT_CUSTOM_DECLARE // LV_FONT_DECLARE(lv_font_heb_16)
 
 /*Always set a default font from the built-in fonts*/
+#ifndef LV_FONT_DEFAULT
 #define LV_FONT_DEFAULT        &lv_font_roboto_16
+#endif  // #ifndef LV_FONT_DEFAULT
 
 /* Enable it if you have fonts with a lot of characters.
  * The limit depends on the font size, font face and bpp

--- a/lv_conf.h
+++ b/lv_conf.h
@@ -302,9 +302,13 @@ typedef void * lv_indev_drv_user_data_t;            /*Type of user data in the i
 
 /* Robot fonts with bpp = 4
  * https://fonts.google.com/specimen/Roboto  */
+#ifndef LV_FONT_ROBOTO_12
 #define LV_FONT_ROBOTO_12    0
+#endif  // LV_FONT_ROBOTO_12
 #define LV_FONT_ROBOTO_16    1
+#ifndef LV_FONT_ROBOTO_22
 #define LV_FONT_ROBOTO_22    0
+#endif  // LV_FONT_ROBOTO_22
 #define LV_FONT_ROBOTO_28    1
 
 /* Demonstrate special features */


### PR DESCRIPTION
Add the following optional defines to override default font settings:

 - `LV_FONT_DEFAULT`: change the default from `&lv_font_roboto_16`
 - `LV_FONT_ROBOTO_12=1`: include Roboto 12pt font (not included by default)
 - `LV_FONT_ROBOTO_22=1`: include Roboto 22pt font (not included by default)

These changes were recommended by #54 .